### PR TITLE
Show command output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "agent",
  "async-trait",
  "cloudagent-python",
+ "colored",
  "log",
 ]
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ We highly recommend using `environment`s to avoid the repetitive task of
 specifying agent URLs. With this CLI you can get up and running with our
 community agent as your default environment, or use your own agent.
 
+If you are getting started with the tool, we recommend enabling informational logs by
+passing the `--verbose` (or `-v`) flag to get more information about what the CLI is
+doing.
+
 ## Common examples
 
 Below you will find some of the most common useful commands within the Aries CLI. To see all options, simply use the `--help` or `-h` flag.
@@ -82,7 +86,7 @@ Below you will find some of the most common useful commands within the Aries CLI
 ### Creating an invitation for the toolbox
 
 ```sh
-aries-cli --copy --quiet connections invite --toolbox
+aries-cli --copy --verbose connections invite --toolbox
 ```
 
 With this quick-fire way of creating an invite to the [Aries toolbox](https://github.com/hyperledger/aries-toolbox) you can continue

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ community agent as your default environment, or use your own agent.
 
 If you are getting started with the tool, we recommend enabling informational logs by
 passing the `--verbose` (or `-v`) flag to get more information about what the CLI is
-doing.
+doing. We also support stacking verbosity up to three levels for debug logs: `-vv` and `-vvv`.
 
 ## Common examples
 

--- a/cli/src/modules/configuration.rs
+++ b/cli/src/modules/configuration.rs
@@ -28,7 +28,7 @@ pub async fn parse_configuration_args(options: &ConfigurationOptions) -> Result<
     match options.commands {
         ConfigurationSubcommands::Initialize => {
             initialize(&config_path)?;
-            info!(
+            println!(
                 "{} configuration file at {}.",
                 "Initialised".cyan(),
                 config_path.display()

--- a/cli/src/modules/connections.rs
+++ b/cli/src/modules/connections.rs
@@ -82,7 +82,7 @@ pub async fn parse_connection_args(
                     println!("{}", response.connection_id);
                     if *qr {
                         info!("Scan this QR code to accept the invitation:\n");
-                        info!("{}: {}", "Connection id".green(), response.connection_id);
+                        println!("{}: {}", "Connection id".green(), response.connection_id);
                         print_qr_code(response.invitation_url).unwrap();
                     } else {
                         info!("Another agent can use this URL to accept your invitation:\n");
@@ -125,7 +125,7 @@ pub async fn parse_connection_args(
                     .await
                     .map(|connection| {
                         debug!("{}", pretty_stringify_obj(&connection));
-                        info!("{}: {}", "Connection id".green(), connection.connection_id);
+                        println!("{}: {}", "Connection id".green(), connection.connection_id);
                     })
             }
         },

--- a/cli/src/modules/connections.rs
+++ b/cli/src/modules/connections.rs
@@ -12,7 +12,6 @@ use crate::help_strings::HelpStrings;
 use crate::utils::logger::pretty_stringify_obj;
 use crate::utils::{
     loader::{Loader, LoaderVariant},
-    logger::pretty_print_obj,
     qr::print_qr_code,
 };
 

--- a/cli/src/modules/connections.rs
+++ b/cli/src/modules/connections.rs
@@ -124,7 +124,8 @@ pub async fn parse_connection_args(
                     .await
                     .map(|connection| {
                         debug!("{}", pretty_stringify_obj(&connection));
-                        println!("{}: {}", "Connection id".green(), connection.connection_id);
+                        info!("{} connection id:", "Fetched".green());
+                        println!("{}", connection.connection_id);
                     })
             }
         },

--- a/cli/src/modules/credential_definition.rs
+++ b/cli/src/modules/credential_definition.rs
@@ -65,10 +65,11 @@ pub async fn parse_credential_definition_args(
         },
         None => agent.get_all().await.map(|cred_defs| {
             loader.stop();
+            info!("{} credential definition IDs:", "Fetched".green());
             cred_defs
                 .credential_definition_ids
                 .iter()
-                .for_each(|x| info!("{}", x))
+                .for_each(|x| println!("{}", x))
         }),
     }
 }

--- a/cli/src/modules/credential_definition.rs
+++ b/cli/src/modules/credential_definition.rs
@@ -65,11 +65,14 @@ pub async fn parse_credential_definition_args(
         },
         None => agent.get_all().await.map(|cred_defs| {
             loader.stop();
-            info!("{} credential definition IDs:", "Fetched".green());
             cred_defs
                 .credential_definition_ids
                 .iter()
-                .for_each(|x| println!("{}", x))
+                .for_each(|x| println!("{}", x));
+            info!(
+                "{} fetched credential definition IDs",
+                "Sucessfully".green()
+            );
         }),
     }
 }

--- a/cli/src/modules/schema.rs
+++ b/cli/src/modules/schema.rs
@@ -7,7 +7,6 @@ use crate::{
     copy,
     error::{Error, Result},
     help_strings::HelpStrings,
-    utils::logger::pretty_print_obj,
     utils::{
         loader::{Loader, LoaderVariant},
         logger::pretty_stringify_obj,

--- a/cli/src/modules/schema.rs
+++ b/cli/src/modules/schema.rs
@@ -70,8 +70,8 @@ pub async fn parse_schema_args(options: &SchemaOptions, agent: impl SchemaModule
         },
         None => agent.get_all().await.map(|schemas| {
             loader.stop();
-            info!("{} schema IDs:", "Fetched".green());
-            schemas.schema_ids.iter().for_each(|x| println!("{}", x))
+            schemas.schema_ids.iter().for_each(|x| println!("{}", x));
+            info!("{} fetched schema IDs", "Successfully".green());
         }),
     }
 }

--- a/cli/src/modules/schema.rs
+++ b/cli/src/modules/schema.rs
@@ -1,5 +1,6 @@
 use agent::modules::schema::{SchemaCreateOptions, SchemaModule};
 use clap::{Args, Subcommand};
+use colored::*;
 use log::{debug, info};
 
 use crate::{
@@ -70,7 +71,8 @@ pub async fn parse_schema_args(options: &SchemaOptions, agent: impl SchemaModule
         },
         None => agent.get_all().await.map(|schemas| {
             loader.stop();
-            schemas.schema_ids.iter().for_each(|x| info!("{}", x))
+            info!("{} schema IDs:", "Fetched".green());
+            schemas.schema_ids.iter().for_each(|x| println!("{}", x))
         }),
     }
 }

--- a/cli/src/utils/logger.rs
+++ b/cli/src/utils/logger.rs
@@ -1,5 +1,5 @@
 use clipboard::{ClipboardContext, ClipboardProvider};
-use log::{info, LevelFilter};
+use log::LevelFilter;
 use serde::Serialize;
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
 

--- a/cli/src/utils/logger.rs
+++ b/cli/src/utils/logger.rs
@@ -51,10 +51,6 @@ pub fn pretty_stringify_obj(obj: impl Serialize) -> String {
     String::from_utf8(ser.into_inner()).unwrap()
 }
 
-pub fn pretty_print_obj(obj: impl Serialize) {
-    info!("{}", pretty_stringify_obj(obj));
-}
-
 pub fn copy_to_clipboard(string: impl AsRef<str>) {
     let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
     ctx.set_contents(string.as_ref().to_string()).unwrap();

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,4 +57,4 @@ we have built in different log-levels:
 This means **by default** we will only log command output, warnings and errors.
 
 **Note**: for command output, we use `println!` to ensure that the result of a command
-returned on stdout.
+returned on stdout. This implies output printed via `println!` should be machine readable.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,4 +57,5 @@ we have built in different log-levels:
 This means **by default** we will only log command output, warnings and errors.
 
 **Note**: for command output, we use `println!` to ensure that the result of a command
-returned on stdout. This implies output printed via `println!` should be machine readable.
+returned on stdout. This implies output printed via `println!` should be machine readable a
+few exceptions.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,3 +40,21 @@ encourage you to take a look at [Rust's guide](https://doc.rust-lang.org/book/ch
 to provide support for writing tests on the PR.
 
 Currently a simple suite of tests can be executed by running `./tests/run.sh`.
+
+
+### Using log levels
+
+We believe that good logging makes for a good CLI user experience but we also believe
+a productivity focussed tool should not flood the terminal with logging. That is why
+we have built in different log-levels:
+
+| CLI flags | Rust logger | Description |
+| --------- | ----------- | ----------- |
+| `--verbose` or `-v` | `info!` | up to **informational**-level logging |
+| `--verbose --verbose` or `-vv` | `debug!` | up to **debug**-level logging |
+| `--verbose --verbose --verbose` or `-vvv` | `trace!` | up to **trace**-level logging |
+
+This means **by default** we will only log command output, warnings and errors.
+
+**Note**: for command output, we use `println!` to ensure that the result of a command
+returned on stdout.

--- a/workflow/Cargo.toml
+++ b/workflow/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 cloudagent-python = {path = "../cloudagent-python"}
+colored = "2.0.0"
 agent = {path = "../agent"}
 async-trait = "0.1.51"
 log = "0.4.14"

--- a/workflow/src/workflows/credential_offer.rs
+++ b/workflow/src/workflows/credential_offer.rs
@@ -5,6 +5,7 @@ use agent::modules::{
     credentials::{CredentialsModule, CredentialsOfferOptions},
     schema::{SchemaCreateOptions, SchemaModule},
 };
+use colored::*;
 use log::trace;
 use std::collections::HashMap;
 
@@ -28,14 +29,14 @@ impl CredentialOfferWorkflow {
             self.attributes.values().map(|e| e.to_owned()).collect();
 
         // Check if it as a valid connection
-        println!("Fetching the connection...");
+        println!("{} the connection...", "Fetching".cyan());
         let connection = ConnectionModule::get_by_id(&agent, self.connection_id.to_owned()).await?;
         if connection.state != "active" {
             return Err(Error::ConnectionNotReady.into());
         }
 
         // Create or fetch the schema
-        println!("Registering the schema...");
+        println!("{} the schema...", "Registering".cyan());
         let schema = SchemaModule::create(
             &agent,
             SchemaCreateOptions {
@@ -46,12 +47,12 @@ impl CredentialOfferWorkflow {
         )
         .await?;
 
-        println!("Registering the credential definition...");
+        println!("{} the credential definition...", "Registering".cyan());
         // Create or fetch the credential definition
         let credential_definition =
             CredentialDefinitionModule::create(&agent, schema.schema_id).await?;
 
-        println!("Offering the credential...");
+        println!("{} the credential...", "Offering".cyan());
         let credential_offer_response = agent
             .send_offer(CredentialsOfferOptions {
                 keys: attribute_keys,


### PR DESCRIPTION
Mainly a fix to always show relevant command output when appropriate. For example, when listing all credential definitions.

Also updated contributing documentation with reasoning for when to use what type of logging.