### PR TITLE
Making README shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@
 
 
 <p align="center">
-<a href="#roadmap">Roadmap</a> &nbsp;|&nbsp;
+
   <a href="#getting-started">Getting started</a> &nbsp;|&nbsp;
   <a href="#common-examples">Common examples</a> &nbsp;|&nbsp;
-   <a href="#contributing">Contributing</a> 
+  <a href="#roadmap">Roadmap</a> &nbsp;|&nbsp;
+  <a href="#contributing">Contributing</a> 
     
 </p>
 
@@ -32,27 +33,11 @@
 
 Aries CLI is the most convenient way for self-sovereign identity (SSI) developers to interact with SSI agents.
 
-Building an SSI solution requires many, _many_ interactions with an SSI agent. Each interaction, often comprised of multiple steps, must be furnished with an endpoint and associated data. The Aries CLI makes working with verifiable credentials easy by giving users:
-
 * 🌐 **Environments** to easily manage configuration for multiple projects and agents
 * 🌟 **Actions and workflows** that you can perform against an agent
 * 💅🏻 **Mock data** so that you can focus on the important task of building your application instead of other foobar (coming soon 🚧)
 
-This README was set up for you to get started as fast as possible. If you are looking for more information about the concepts, example code and tutorials on how to use the CLI we recommend you check out our extensive [docs](https://github.com/animo/aries-cli/pull/www.google.com).
-
-## Roadmap
-
-<!-- TODO: Add more details about the actions and features we support -->
-We intend to support multiple versions of the Aries agent. See the CLI help `aries-cli --help` for a list of actions we currently support.
-
-Next we are looking at adding:
-
-| Feature          | Status | Description                                                                           |
-| ---------------- | ------ | ------------------------------------------------------------------------------------- |
-| Mock data        | 🚧      | Generate mock data for large data structures like schemas and credential definitions. |
-| Filters          | 🚧      | Use filters to determine what server output you want returned.                        |
-| Workflows        | 🚧      | Chain multiple actions together for higher-level goals like: issue a credential.      |
-| Present proof    | 🚧      | Present proofs.                                                                       |
+If you are looking for more information about the concepts, example code and tutorials on how to use the CLI we recommend you check out our extensive [docs](https://github.com/animo/aries-cli/pull/www.google.com).
 
 
 ## Getting started
@@ -77,35 +62,43 @@ echo "Coming soon!"
 Write-Output "Coming soon!"
 ```
 
+### Binaries
+
+See [binaries](https://github.com/animo/aries-cli/releases).
+
 ### Setting up your environment
 
 ```sh
 aries-cli configuration initialize
+# > /location/of/the/config/file
 ```
 
-We highly recommend using `environment`s to avoid the repetitive task of
-specifying agent URLs. With this CLI you can get up and running with our
-community agent as your default environment, or use your own agent.
+This command will set up the community agent. To set up your own agent edit
+the configuration file by adding your agent URL.
 
-If you are getting started with the tool, we recommend enabling informational logs by
-passing the `--verbose` (or `-v`) flag to get more information about what the CLI is
-doing. We also support stacking verbosity up to three levels for debug logs: `-vv` and `-vvv`.
+If you are getting started with the tool we recommend enabling informational logs by
+passing the `--verbose` (or `-v`).
 
 ## Common examples
 
-Below you will find some of the most common useful commands within the Aries CLI. To see all options, simply use the `--help` or `-h` flag.
+To see all actions simply use the `--help` or `-h` flag. Here are some common actions.
 
-### Creating an invitation for the toolbox
+### Create a credential offer
+
+```sh
+aries-cli execute offer-credential
+```
+
+ Get a credential offer in your wallet &mdash; this command will execute all of the actions needed.
+
+
+### Create an invitation for the toolbox
 
 ```sh
 aries-cli --copy --verbose connections invite --toolbox
 ```
 
-With this quick-fire way of creating an invite to the [Aries toolbox](https://github.com/hyperledger/aries-toolbox) you can continue
-with the task at hand: testing an invitation workflow for your app. This
-command takes care of all the plumbing.
-
-The `--toolbox` flag makes sure the invite has an alias as Toolbox, sets auto accept to true and sets the toolbox as admin for the invite.
+The `--toolbox` flag creates an invitation for the [Toolbox](https://github.com/hyperledger/aries-toolbox).
 
 The `--copy` flag will copy the invite URL to your clipboard so it can easily be pasted in the toolbox
 
@@ -116,6 +109,21 @@ For more options under the `connections invite` subcommand see:
 ```
 aries-cli connections invite --help
 ```
+
+
+## Roadmap
+
+<!-- TODO: Add more details about the actions and features we support -->
+We intend to support multiple versions of the Aries agent. See the CLI help `aries-cli --help` for a list of actions we currently support.
+
+Next we are looking at adding:
+
+| Feature          | Status | Description                                                                           |
+| ---------------- | ------ | ------------------------------------------------------------------------------------- |
+| Mock data        | 🚧      | Generate mock data for large data structures like schemas and credential definitions. |
+| Filters          | 🚧      | Use filters to determine what server output you want returned.                        |
+| execute offer-credential  |   ✅    | Execute sequence of actions to get a credential offer in your wallet.      |
+| Present proof    | 🚧      | Present proofs.                                                                       |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@
 
 
 <p align="center">
-
-  <a href="#getting-started">Getting started</a> &nbsp;|&nbsp;
+<a href="#getting-started">Getting started</a> &nbsp;|&nbsp;
   <a href="#common-examples">Common examples</a> &nbsp;|&nbsp;
   <a href="#roadmap">Roadmap</a> &nbsp;|&nbsp;
   <a href="#contributing">Contributing</a> 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ Write-Output "Coming soon!"
 ### Binaries
 
 See [binaries](https://github.com/animo/aries-cli/releases).
+### Cargo install
 
+```sh
+cargo install --git https://github.com/animo/aries-cli
 ### Setting up your environment
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The `--toolbox` flag creates an invitation for the [Toolbox](https://github.com/
 
 The `--copy` flag will copy the invite URL to your clipboard so it can easily be pasted in the toolbox
 
-Optionally, add the `--quiet` flag to suppress output to stdout.
+Replace `--verbose` with `--quiet` to suppress non-essential output to stdout.
 
 For more options under the `connections invite` subcommand see:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <h1 align="center" ><b>Aries CLI</b></h1>
 
 
-<h3 align="center">Powered By &nbsp; <img src="./images/animo-logo-dark-background.png#gh-dark-mode-only" height="12px"><img src="./images/animo-logo-light-background.png#gh-light-mode-only" height="12px"></h3><br>
+<h3 align="center">Powered by &nbsp; <img src="./images/animo-logo-dark-background.png#gh-dark-mode-only" height="12px"><img src="./images/animo-logo-light-background.png#gh-light-mode-only" height="12px"></h3><br>
 
 
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,7 @@
 # Contributing
 
-We welcome contributions that to make the CLI better. If you do not have a specific
-contribution in mind we encourage you to look for issues labelled with as
-`good first issue` or look for missing actions in our [support matrix](./support_matrix.md).
+We welcome contributions that make the CLI better. If you do not have a specific
+contribution in mind look for issues labelled as `good first issue`.
 
 ## Fixes
 
@@ -11,12 +10,12 @@ If you have a fix, go straight to "Getting set up".
 ## Features
 
 If you have something bigger in mind (structural changes, new features) we strongly
-encourage you to create a new GitHub issue that documents:
+encourage you to create a new GitHub issue with:
 
-* motivate the changes you want to make
-* how you want to make them
+* motivation for the changes you want to make
+* approach for how you want to make them
 
-This gives your new idea the best chance to get accepted by the repository
+This gives your new idea the best chance to get accepted by the
 maintainers.
 
 ## Getting set up
@@ -25,8 +24,7 @@ maintainers.
 git clone https://github.com/animo/aries-cli.git
 ```
 
-Once you have the code locally, you should be able to test out the current
-source code by running:
+Once you have the code locally you can run commands using:
 
 ```sh
 # "cargo run -q --" instead of aries-cli
@@ -35,18 +33,18 @@ cargo run -q -- <cmd>
 
 ### Tests
 
-We love tests, but recognize that there is a shortage of them at the moment. We
-encourage you to take a look at [Rust's guide](https://doc.rust-lang.org/book/ch11-01-writing-tests.html) on how to create an automated test. We are happy
-to provide support for writing tests on the PR.
+We love tests, but recognize that there is a shortage of them at the moment. Take a look at
+[Rust's guide](https://doc.rust-lang.org/book/ch11-01-writing-tests.html) on how to create an automated test. We are happy
+to provide support for writing tests on your PR.
 
-Currently a simple suite of tests can be executed by running `./tests/run.sh`.
+A simple suite of tests can be executed by running `./tests/run.sh`.
 
 
 ### Using log levels
 
-We believe that good logging makes for a good CLI user experience but we also believe
-a productivity focussed tool should not flood the terminal with logging. That is why
-we have built in different log-levels:
+We believe that good logging makes for a good CLI user experience. However,
+a productivity focussed tool should not flood the terminal with logs. That is why
+we have different log-levels:
 
 | CLI flags | Rust logger | Description |
 | --------- | ----------- | ----------- |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,5 +55,4 @@ we have different log-levels:
 This means **by default** we will only log command output, warnings and errors.
 
 **Note**: for command output, we use `println!` to ensure that the result of a command
-returned on stdout. This implies output printed via `println!` should be machine readable a
-few exceptions.
+returned on stdout. This implies output printed via `println!` should be machine readable.


### PR DESCRIPTION
* Move Roadmap to just above contributing so that Getting started is on top
* Added link to releases page
* Tightened up language _a lot_

Preview: https://github.com/animo/aries-cli/tree/Making-README-shorter