### PR TITLE
fix: renamed workflows to automate

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -52,5 +52,5 @@ pub enum Commands {
     Message(MessageOptions),
     Credentials(CredentialOptions),
     Configuration(ConfigurationOptions),
-    Workflow(WorkflowOptions),
+    Automate(WorkflowOptions),
 }

--- a/cli/src/register.rs
+++ b/cli/src/register.rs
@@ -96,7 +96,7 @@ pub async fn register() -> Result<()> {
             )?;
             parse_credentials_args(&options.commands, agent).await
         }
-        Commands::Workflow(options) => {
+        Commands::Automate(options) => {
             let agent = initialize_agent_from_cli(
                 cli.config,
                 cli.environment,


### PR DESCRIPTION
- Very controversial
- Internally workflows will still be used as it is the best name.

﻿Signed-off-by: Berend Sliedrecht <berend@animo.id>
