### PR TITLE
feat: added support for revocation and tags in credential definition

### DIFF
--- a/agent/src/modules/credential_definition.rs
+++ b/agent/src/modules/credential_definition.rs
@@ -3,6 +3,16 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct CredentialDefinitionCreateOptions {
+    pub schema_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    pub support_revocation: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocation_registry_size: Option<i32>,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CredentialDefinitionCreateResponse {
     pub credential_definition_id: String,
@@ -35,7 +45,10 @@ pub struct CredentialDefinitionGetAllResponse {
 #[async_trait]
 pub trait CredentialDefinitionModule {
     /// Requests all the features from the cloudagent
-    async fn create(&self, schema_id: String) -> Result<CredentialDefinitionCreateResponse>;
+    async fn create(
+        &self,
+        options: CredentialDefinitionCreateOptions,
+    ) -> Result<CredentialDefinitionCreateResponse>;
     async fn get_by_id(&self, id: String) -> Result<CredentialDefinitionGetByIdResponse>;
     async fn get_all(&self) -> Result<CredentialDefinitionGetAllResponse>;
 }

--- a/cli/src/help_strings.rs
+++ b/cli/src/help_strings.rs
@@ -41,6 +41,9 @@ pub enum HelpStrings {
     CredentialDefinitionId,
     CredentialDefinitionCreate,
     CredentialDefinitionCreateSchemaId,
+    CredentialDefinitionCreateTag,
+    CredentialDefinitionCreateSupportRevocation,
+    CredentialDefinitionCreateRevocationRegistrySize,
     CredentialDefinitionList,
 
     // Credentials
@@ -137,6 +140,9 @@ impl HelpStrings {
             HelpStrings::CredentialDefinitionId => "ID of a credential definition to retrieve",
             HelpStrings::CredentialDefinitionCreate => "Create a new credential definition",
             HelpStrings::CredentialDefinitionCreateSchemaId => "Schema ID to use in the definition",
+            HelpStrings::CredentialDefinitionCreateTag => "Tag for the credential definition",
+            HelpStrings::CredentialDefinitionCreateSupportRevocation => "Whether the credential definition should support revocation",
+            HelpStrings::CredentialDefinitionCreateRevocationRegistrySize => "The size of the revocation registry",
             HelpStrings::CredentialDefinitionList => "List all your credential definitions",
 
             HelpStrings::Credentials => "Issue Credential V1",

--- a/cloudagent-python/src/agent_python/credential_definition.rs
+++ b/cloudagent-python/src/agent_python/credential_definition.rs
@@ -1,22 +1,24 @@
 use super::agent::CloudAgentPython;
 use agent::error::Result;
 use agent::modules::credential_definition::{
-    CredentialDefinitionCreateResponse, CredentialDefinitionGetAllResponse,
-    CredentialDefinitionGetByIdResponse, CredentialDefinitionModule,
+    CredentialDefinitionCreateOptions, CredentialDefinitionCreateResponse,
+    CredentialDefinitionGetAllResponse, CredentialDefinitionGetByIdResponse,
+    CredentialDefinitionModule,
 };
 use async_trait::async_trait;
 use serde_json::json;
 
 #[async_trait]
 impl CredentialDefinitionModule for CloudAgentPython {
-    async fn create(&self, schema_id: String) -> Result<CredentialDefinitionCreateResponse> {
+    async fn create(
+        &self,
+        options: CredentialDefinitionCreateOptions,
+    ) -> Result<CredentialDefinitionCreateResponse> {
         let url = self
             .cloud_agent
             .create_url(vec!["credential-definitions"])?;
 
-        let body = json!({
-          "schema_id": schema_id,
-        });
+        let body = json!(options);
 
         self.cloud_agent.post(url, None, Some(body)).await
     }

--- a/workflow/src/workflows/credential_offer.rs
+++ b/workflow/src/workflows/credential_offer.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, Result};
 use agent::modules::{
     connection::ConnectionModule,
     credential::{CredentialModule, CredentialOfferOptions},
-    credential_definition::CredentialDefinitionModule,
+    credential_definition::{CredentialDefinitionCreateOptions, CredentialDefinitionModule},
     schema::{SchemaCreateOptions, SchemaModule},
 };
 use colored::*;
@@ -47,10 +47,14 @@ impl CredentialOfferWorkflow {
         )
         .await?;
 
+        let options = CredentialDefinitionCreateOptions {
+            schema_id: schema.schema_id,
+            ..CredentialDefinitionCreateOptions::default()
+        };
+
         println!("{} the credential definition...", "Registering".cyan());
         // Create or fetch the credential definition
-        let credential_definition =
-            CredentialDefinitionModule::create(&agent, schema.schema_id).await?;
+        let credential_definition = CredentialDefinitionModule::create(&agent, options).await?;
 
         println!("{} the credential...", "Offering".cyan());
         let credential_offer_response = agent


### PR DESCRIPTION
- Draft for now as I have to confirm a minor detail still.
- Adds support for the `tag`, `support_revocation` and `revocation_registry_size` when registering a credential definition.

closes #140 

Signed-off-by: blu3beri <berend@animo.id>